### PR TITLE
Use real, shell-expanded paths when adding sites

### DIFF
--- a/app/Commands/Add.php
+++ b/app/Commands/Add.php
@@ -180,7 +180,7 @@ class Add extends Command
         $this->validateArguments();
 
         $this->requestedVersion = $this->getVersionOption();
-        $this->installPath = $this->getInstallPathOption();
+        $this->installPath = getRealPath($this->getInstallPathOption());
         $this->hostname = $this->getHostnameOption();
         $this->port = $this->getPortOption();
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Gets the real path of a file with all shell expansions resolved.
+ *
+ * Note that I tried calling PHP's realpath(), but this didn't expand
+ * the ~ character to the home directory as I expected.
+ *
+ * @return void
+ */
+function getRealPath( string $path ) : string
+{
+    exec("echo $path", $output, $resultCode);
+
+    if ($resultCode !== 0) {
+        throw new \Exception("Failed to get expanded path for $path");
+    }
+
+    return $output[0];
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,13 @@
 {
     "name": "laravel-zero/laravel-zero",
     "description": "The Laravel Zero Framework.",
-    "keywords": ["framework", "laravel", "laravel zero", "console", "cli"],
+    "keywords": [
+        "framework",
+        "laravel",
+        "laravel zero",
+        "console",
+        "cli"
+    ],
     "homepage": "https://laravel-zero.com",
     "type": "project",
     "license": "MIT",
@@ -30,6 +36,9 @@
         "pestphp/pest": "^2.5"
     },
     "autoload": {
+        "files": [
+            "app/helpers.php"
+        ],
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
@@ -51,5 +60,7 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "bin": ["qwp"]
+    "bin": [
+        "qwp"
+    ]
 }


### PR DESCRIPTION
Resolves #21 

Note that there didn't seem to be a simple way in Laravel or PHP to shell-expand a path. So I had to fudge it a bit.