### PR TITLE
Use the real, shell-expanded path when configuring the default path

### DIFF
--- a/app/Commands/Config.php
+++ b/app/Commands/Config.php
@@ -40,6 +40,8 @@ class Config extends Command
             return;
         }
 
+        $defaultPath = getRealPath($defaultPath);
+
         if (! File::exists($defaultPath)) {
             $create = $this->confirm("$defaultPath does not exist, do you want me to create it?", true);
             if ($create) {


### PR DESCRIPTION
Resolves #3 